### PR TITLE
TASK: Agregar Admin Panel DEV a Origin para evitar CORS

### DIFF
--- a/src/main/java/com/ucu/taisback/TaisBackApplication.java
+++ b/src/main/java/com/ucu/taisback/TaisBackApplication.java
@@ -37,13 +37,13 @@ public class TaisBackApplication {
 	public CorsFilter corsFilter(){
 		CorsConfiguration corsConfiguration = new CorsConfiguration();
 		corsConfiguration.setAllowCredentials(true);
-		corsConfiguration.setAllowedOrigins(Arrays.asList("http://localhost:4200","https://qrlink-dev.web.app/"));
+		corsConfiguration.setAllowedOrigins(Arrays.asList("http://localhost:4200", "https://qrlink-dev.web.app/", "https://qrlink-dev-admin.web.app"));
 		corsConfiguration.setAllowedHeaders(Arrays.asList("Origin","Access-Control-Allow-Origin","Content-Type",
 				"Accept","Authorization","Origin, Accept", "X-Requested-With","Access-Control-Request-Method",
 				"Access-Control-Request-Headers"));
 		corsConfiguration.setExposedHeaders(Arrays.asList("Origin","Content-Type","Accept","Authorization",
 				"Access-Control-Allow-Origin","Access-Control-Allow-Credentials"));
-		corsConfiguration.setAllowedMethods(Arrays.asList("GET","POST","PUT","DELETE","OPTIONS"));
+		corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"));
 		UrlBasedCorsConfigurationSource urlBasedCorsConfigurationSource = new UrlBasedCorsConfigurationSource();
 		urlBasedCorsConfigurationSource.registerCorsConfiguration("/**",corsConfiguration);
 		return new CorsFilter( urlBasedCorsConfigurationSource);

--- a/src/main/java/com/ucu/taisback/TaisBackApplication.java
+++ b/src/main/java/com/ucu/taisback/TaisBackApplication.java
@@ -37,7 +37,7 @@ public class TaisBackApplication {
 	public CorsFilter corsFilter(){
 		CorsConfiguration corsConfiguration = new CorsConfiguration();
 		corsConfiguration.setAllowCredentials(true);
-		corsConfiguration.setAllowedOrigins(Arrays.asList("http://localhost:4200", "https://qrlink-dev.web.app/", "https://qrlink-dev-admin.web.app"));
+		corsConfiguration.setAllowedOrigins(Arrays.asList("http://localhost:4200", "https://qrlink-dev.web.app/", "https://qrlink.web.app/", "https://qrlink-dev-admin.web.app", "https://qrlink-admin.web.app"));
 		corsConfiguration.setAllowedHeaders(Arrays.asList("Origin","Access-Control-Allow-Origin","Content-Type",
 				"Accept","Authorization","Origin, Accept", "X-Requested-With","Access-Control-Request-Method",
 				"Access-Control-Request-Headers"));


### PR DESCRIPTION
Agregué la URL del admin panel de DEV y PROD, y además agregué la URL de la web de usuario para PROD, así ya quedan todas configuradas. 

Otra cosa que agregué fue el HTTP HEAD como aceptado, ya que de esa manera estarán llamando a nuestro endpoint desde aplicaciones de terceros. 

**Nota: Hay que ver cómo funciona eso con CORS, porque capaz que tenemos que habilitar cualquier origen pero solo para el endpoint de getProductResources().**